### PR TITLE
add more tags to http tracing

### DIFF
--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -25,6 +25,8 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 		tracer.ResourceName(resource),
 		tracer.Tag(ext.HTTPMethod, r.Method),
 		tracer.Tag(ext.HTTPURL, r.URL.Path),
+		tracer.Tag("http.hostname", r.URL.Hostname),
+		tracer.Tag("http.content-length", r.ContentLength),
 	}, spanopts...)
 	if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
 		opts = append(opts, tracer.ChildOf(spanctx))


### PR DESCRIPTION
Adding url host (and content-length for kicks) so we can better understand how long requests to various external hosts (e.g. aws) are taking. 

This is all we get now out of the box:
![Screen Shot 2019-09-27 at 4 28 35 PM](https://user-images.githubusercontent.com/40863619/65800371-4e591f00-e144-11e9-90c4-9306c552e3eb.png)
